### PR TITLE
StructCache bugfix when passing "args" directly from the parameters

### DIFF
--- a/src/main/kotlin/org/jire/arrowhead/StructCache.kt
+++ b/src/main/kotlin/org/jire/arrowhead/StructCache.kt
@@ -39,11 +39,12 @@ object StructCache {
 		var struct = map[type]
 		if (struct == null) {
 			struct = (if (args.isNotEmpty()) {
-				val types = arrayOfNulls<Class<*>>(args.size)
-				type.declaredFields.forEachIndexed { i, field -> types[i] = field.type }
+				val types = type.declaredFields.map { it.type }.toTypedArray()
 				val constructor = type.getDeclaredConstructor(*types)
 				constructor.newInstance(*args)
-			} else type.getDeclaredConstructor().newInstance()) as T
+			} else {
+				type.getDeclaredConstructor().newInstance()
+			}) as T
 			map[type] = struct
 		}
 		return struct as T
@@ -65,4 +66,4 @@ object StructCache {
  * @param args The arguments to pass to the constructor of the struct.
  */
 inline operator fun <reified T : Struct> KClass<T>.get(vararg args: Any)
-		= StructCache[this, args] // Explosions can't be passed to get operator... a bug perhaps?
+		= StructCache.get(this, *args) // Explosions can't be passed to get operator... a bug perhaps?


### PR DESCRIPTION
Bug where passing args directly from varargs creates, for some reason, a list of a list so the cache system wasn't working properly. Watch the ```get()``` extension for the KClass. Probably a Kotlin bug?

I used this code to test the fix and looks like it works. Also works just fine using the empty constructor. ```.get()```
```kotlin
fun main(args: Array<String>) {
    val x = VectorX::class[1.0, 2.0, 3.0]
    println(x)
}

class VectorX(
        @JvmField
        var x: Double = 0.0,
        @JvmField
        var y: Double = 0.0,
        @JvmField
        var z: Double = 0.0
) : Struct()
```

This was the error I was getting using the library in my project.
![image](https://user-images.githubusercontent.com/20285526/84592982-bd4ce400-ae49-11ea-8e7c-e3a2f0ad1a68.png)